### PR TITLE
feat: Lee client feedback — contact, sort/filter, place detail polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Contact Us page with Historic Sites email (`historic.sites@yukon.ca`) and phone (`867-667-5386`)
+- Places list sorting by name, community, or designation type (client-side over full register)
+- Cultural History expansion panel on place detail (ready for YHIS `culturalHistoryEn`/`Fr`; not yet exposed by public register API)
 - Added PlaceLocationMap component for displaying individual place locations
 - Interactive map marker with custom teal pin design
 - Added base layer switcher with Streets, Satellite, and Terrain options
@@ -36,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Emphasized home page intro as a bold central heading with continuous larger body text
+- Place detail: description under site name; gallery height aligned with map; photos use contain (less cropping); captions shown once; expansion panels open by default
+- Renamed "Character Definition" label to "Character-Defining Elements"
 - Switched places frontend from mock data to the live YHIS register API (`https://yhis.gov.yk.ca/api/register`)
 - Fixed backend place list pagination to use YHIS `?page=` (was sending ignored `skip`/`take` params)
 - Aligned backend `RegisterPlace` / photo types and detail `{ data }` responses with the live YHIS wire shape and frontend `Place.fromApi`

--- a/src/api/models/register-place.model.ts
+++ b/src/api/models/register-place.model.ts
@@ -45,4 +45,7 @@ export interface RegisterPlace {
   descBoundFr?: string;
   additionalInfoEn?: string;
   additionalInfoFr?: string;
+  /** Cultural history — not yet exposed by YHIS public register (see docs) */
+  culturalHistoryEn?: string;
+  culturalHistoryFr?: string;
 }

--- a/src/docs/architecture/yhis-register-api.md
+++ b/src/docs/architecture/yhis-register-api.md
@@ -109,10 +109,11 @@ Detail includes list fields (including `fr_*` metadata) plus bilingual content p
 | `characterDefEn` / `characterDefFr` | Character-defining elements (type 2) |
 | `descBoundEn` / `descBoundFr` | Boundary description (type 6) |
 | `additionalInfoEn` / `additionalInfoFr` | Additional info (type 30) |
+| `culturalHistoryEn` / `culturalHistoryFr` | **Not mapped yet** — YHRP UI is ready; YHIS `register-router` does not currently populate these. Needs a YHSI description-type mapping before live data appears. |
 
 **French note:** As of Aug 2026, YHIS returns real French description text via `fR_DescriptionText` and French metadata via `fr_primaryName` / `fr_communityName` / `fr_designations`. Some `fr_*` values may still be `null` when a translation is missing — UI should fall back to English.
 
-YHRP keeps these wire names on both the backend `RegisterPlace` model and the frontend `Place` model for consistency.
+YHRP keeps these wire names on both the backend `RegisterPlace` model and the frontend `Place` model for consistency. Cultural History is wired end-to-end in YHRP (model + place-detail panel) and will show when YHIS starts returning the fields (or when using mock data).
 
 404 with empty body when the id is not on the register.
 

--- a/src/web/src/components/NavMenu.vue
+++ b/src/web/src/components/NavMenu.vue
@@ -5,7 +5,11 @@
       <v-list-item to="/map" prepend-icon="mdi-map-outline" :title="t(translations.map)" />
       <v-list-item to="/places" prepend-icon="mdi-information-outline" :title="t(translations.historicPlaces)" />
       <v-divider />
-      <v-list-item prepend-icon="mdi-email" :title="t(translations.contactUs)" />
+      <v-list-item
+        to="/contact"
+        prepend-icon="mdi-email"
+        :title="t(translations.contactUs)"
+      />
     </v-list>
   </v-menu>
 </template>

--- a/src/web/src/locales/translations.csv
+++ b/src/web/src/locales/translations.csv
@@ -28,7 +28,7 @@ photoGallery,Photo Gallery,Galerie photos
 designation,Designation,Désignation
 placeDescription,Place Description,Description du lieu
 heritageValue,Heritage Value,Valeur patrimoniale
-characterDefinition,Character Definition,Définition du caractère
+characterDefinition,Character-Defining Elements,Éléments caractéristiques
 additionalInformation,Additional Information,Informations supplémentaires
 descriptionOfBoundaries,Description of Boundaries,Description des limites
 level,Level,Niveau

--- a/src/web/src/locales/translations.csv
+++ b/src/web/src/locales/translations.csv
@@ -31,6 +31,7 @@ heritageValue,Heritage Value,Valeur patrimoniale
 characterDefinition,Character-Defining Elements,Éléments caractéristiques
 additionalInformation,Additional Information,Informations supplémentaires
 descriptionOfBoundaries,Description of Boundaries,Description des limites
+culturalHistory,Cultural History,Histoire culturelle
 level,Level,Niveau
 date,Date,Date
 # STATUS & FEEDBACK MESSAGES

--- a/src/web/src/locales/translations.csv
+++ b/src/web/src/locales/translations.csv
@@ -37,6 +37,10 @@ date,Date,Date
 loading,Loading,Chargement
 noPhotosAvailable,No photos available,Aucune photo disponible
 noPlacesFound,No places found,Aucun lieu trouvé
+sortBy,Sort by,Trier par
+sortAlphabetical,Alphabetical,Alphabétique
+sortCommunity,Community,Communauté
+sortDesignation,Designation type,Type de désignation
 # HOME PAGE CONTENT
 heroText,"Historic places in the Yukon are a tangible record of the people, events and activities that have shaped our way of life and our environment.","Les lieux patrimoniaux du Yukon sont un témoignage tangible des personnes, des événements et des activités qui ont façonné notre mode de vie et notre environnement."
 heroSubtext1,"Our historic places represent the technologies, designs and ideas that are the framework of our society and the basis for our future.","Nos lieux patrimoniaux représentent les technologies, les designs et les idées qui constituent le cadre de notre société et la base de notre avenir."

--- a/src/web/src/locales/translations.csv
+++ b/src/web/src/locales/translations.csv
@@ -42,6 +42,9 @@ sortBy,Sort by,Trier par
 sortAlphabetical,Alphabetical,Alphabétique
 sortCommunity,Community,Communauté
 sortDesignation,Designation type,Type de désignation
+filterAll,All,Tous
+filterCommunity,Community,Communauté
+filterDesignation,Designation,Désignation
 # HOME PAGE CONTENT
 heroText,"Historic places in the Yukon are a tangible record of the people, events and activities that have shaped our way of life and our environment.","Les lieux patrimoniaux du Yukon sont un témoignage tangible des personnes, des événements et des activités qui ont façonné notre mode de vie et notre environnement."
 heroSubtext1,"Our historic places represent the technologies, designs and ideas that are the framework of our society and the basis for our future.","Nos lieux patrimoniaux représentent les technologies, les designs et les idées qui constituent le cadre de notre société et la base de notre avenir."

--- a/src/web/src/locales/translations.csv
+++ b/src/web/src/locales/translations.csv
@@ -6,6 +6,10 @@ map,Map,Carte
 historicPlaces,Historic Places,Lieux patrimoniaux
 places,Places,Lieux
 contactUs,Contact Us,Contactez-nous
+# CONTACT PAGE
+contactIntro,"For questions about the Yukon Register of Historic Places, contact Historic Sites.","Pour toute question concernant le Répertoire des lieux patrimoniaux du Yukon, communiquez avec les Lieux historiques."
+contactEmail,Email,Courriel
+contactPhone,Phone,Téléphone
 # ACTIONS & BUTTONS
 viewPlace,View Place,Voir le lieu
 viewDetails,View Details,Voir les détails

--- a/src/web/src/modules/contact/router/index.js
+++ b/src/web/src/modules/contact/router/index.js
@@ -1,0 +1,15 @@
+const routes = [
+  {
+    path: "",
+    component: () => import("@/layouts/Default.vue"),
+    children: [
+      {
+        path: "/contact",
+        name: "contact",
+        component: () => import("../views/Contact.vue"),
+      },
+    ],
+  },
+];
+
+export default routes;

--- a/src/web/src/modules/contact/views/Contact.vue
+++ b/src/web/src/modules/contact/views/Contact.vue
@@ -5,9 +5,9 @@
         <h1 class="text-h4 mb-4">{{ t(translations.contactUs) }}</h1>
         <p class="text-body-1 mb-6">{{ t(translations.contactIntro) }}</p>
 
-        <div class="d-flex flex-column ga-4">
-          <div class="d-flex align-center ga-3">
-            <v-icon color="primary" icon="mdi-email" />
+        <div class="d-flex flex-column">
+          <div class="d-flex align-center mb-10">
+            <v-icon color="primary" icon="mdi-email" class="me-3" />
             <div>
               <div class="text-subtitle-2 text-grey-darken-1">
                 {{ t(translations.contactEmail) }}
@@ -21,8 +21,8 @@
             </div>
           </div>
 
-          <div class="d-flex align-center ga-3">
-            <v-icon color="primary" icon="mdi-phone" />
+          <div class="d-flex align-center">
+            <v-icon color="primary" icon="mdi-phone" class="me-3" />
             <div>
               <div class="text-subtitle-2 text-grey-darken-1">
                 {{ t(translations.contactPhone) }}

--- a/src/web/src/modules/contact/views/Contact.vue
+++ b/src/web/src/modules/contact/views/Contact.vue
@@ -1,0 +1,45 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="8" class="mx-auto">
+        <h1 class="text-h4 mb-4">{{ t(translations.contactUs) }}</h1>
+        <p class="text-body-1 mb-6">{{ t(translations.contactIntro) }}</p>
+
+        <div class="d-flex flex-column ga-4">
+          <div class="d-flex align-center ga-3">
+            <v-icon color="primary" icon="mdi-email" />
+            <div>
+              <div class="text-subtitle-2 text-grey-darken-1">
+                {{ t(translations.contactEmail) }}
+              </div>
+              <a
+                class="text-body-1 text-primary"
+                href="mailto:historic.sites@yukon.ca"
+              >
+                historic.sites@yukon.ca
+              </a>
+            </div>
+          </div>
+
+          <div class="d-flex align-center ga-3">
+            <v-icon color="primary" icon="mdi-phone" />
+            <div>
+              <div class="text-subtitle-2 text-grey-darken-1">
+                {{ t(translations.contactPhone) }}
+              </div>
+              <a class="text-body-1 text-primary" href="tel:+18676675386">
+                867-667-5386
+              </a>
+            </div>
+          </div>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { useLanguage, translations } from "@/composables/useLanguage";
+
+const { t } = useLanguage();
+</script>

--- a/src/web/src/modules/home/views/Home.vue
+++ b/src/web/src/modules/home/views/Home.vue
@@ -7,23 +7,18 @@
     </v-row>
 
     <v-container>
-      <v-row gap="0" class="justify-center">
-        <v-col cols="12" md="8" class="pa-0">
-          <p class="text-h5 font-weight-light mb-2 text-yg_sun">
-            {{ t(translations.heroText) }}
-          </p>
-        </v-col>
-      </v-row>
-
       <v-row class="my-8">
         <v-col cols="12" md="8" class="mx-auto">
-          <p class="text-h6 font-weight-light mb-4">
+          <h2 class="text-h4 font-weight-bold mb-4 text-yg_sun">
+            {{ t(translations.heroText) }}
+          </h2>
+          <p class="text-h6 font-weight-regular mb-4">
             {{ t(translations.heroSubtext1) }}
           </p>
-          <p class="text-body-1">
+          <p class="text-h6 font-weight-regular mb-4">
             {{ t(translations.heroSubtext2) }}
           </p>
-          <p class="text-body-1 mt-4">
+          <p class="text-h6 font-weight-regular">
             {{ t(translations.heroSubtext3) }}
           </p>
         </v-col>

--- a/src/web/src/modules/places/components/PlaceGallery.vue
+++ b/src/web/src/modules/places/components/PlaceGallery.vue
@@ -5,14 +5,13 @@
       :show-arrows="photos.length > 1"
       hide-delimiter-background
       delimiter-icon="mdi-circle"
-      height="400"
+      :height="height"
       @update:model-value="handlePhotoChange"
     >
       <v-carousel-item
         v-for="photo in photos"
         :key="photo.id"
         :src="photo.imageUrl"
-        cover
         class="cursor-pointer"
         @click="openFullscreen(photo)"
       >
@@ -22,12 +21,16 @@
       </v-carousel-item>
     </v-carousel>
 
-    <div v-else class="d-flex flex-column align-center justify-center" style="height: 400px">
+    <div
+      v-else
+      class="d-flex flex-column align-center justify-center"
+      :style="{ height: `${height}px` }"
+    >
       <v-icon size="64" color="grey">mdi-image-off</v-icon>
       <p class="text-grey mt-2">{{ t(translations.noPhotosAvailable) }}</p>
     </div>
 
-    <v-card v-if="currentPhoto?.comments" flat class="mt-2">
+    <v-card v-if="showDistinctComments" flat class="mt-2">
       <v-card-text class="text-body-2 text-grey-darken-1">
         {{ currentPhoto.comments }}
       </v-card-text>
@@ -56,7 +59,6 @@
             v-for="photo in photos"
             :key="photo.id"
             :src="photo.imageUrl"
-            cover
           >
             <div v-if="photo.caption" class="photo-caption">
               {{ photo.caption }}
@@ -69,7 +71,7 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useLanguage, translations } from "@/composables/useLanguage";
 import { fetchPlacePhotos } from "../services/placesApi";
 
@@ -80,6 +82,10 @@ const props = defineProps({
     type: [Number, String],
     required: true,
   },
+  height: {
+    type: [Number, String],
+    default: 400,
+  },
 });
 
 const photos = ref([]);
@@ -87,6 +93,13 @@ const loading = ref(true);
 const fullscreen = ref(false);
 const currentPhotoIndex = ref(0);
 const currentPhoto = ref(null);
+
+const showDistinctComments = computed(() => {
+  const comments = currentPhoto.value?.comments?.trim();
+  if (!comments) return false;
+  const caption = currentPhoto.value?.caption?.trim() || "";
+  return comments !== caption;
+});
 
 const loadPhotos = async () => {
   try {

--- a/src/web/src/modules/places/models/Place.js
+++ b/src/web/src/modules/places/models/Place.js
@@ -46,6 +46,8 @@ export class Place {
     this.descBoundFr = data.descBoundFr || "";
     this.additionalInfoEn = data.additionalInfoEn || "";
     this.additionalInfoFr = data.additionalInfoFr || "";
+    this.culturalHistoryEn = data.culturalHistoryEn || "";
+    this.culturalHistoryFr = data.culturalHistoryFr || "";
   }
 
   /**
@@ -174,7 +176,7 @@ export class Place {
    * @private
    */
   _parseCulturalHistory(data) {
-    return data.heritageValueEn || "";
+    return data.culturalHistoryEn || data.culturalHistory || "";
   }
 
   /**
@@ -211,6 +213,9 @@ export class Place {
    * @static
    */
   static fromMock(data) {
+    const characterItems =
+      data.heritageValues?.[0]?.items || data.heritageValues?.[0]?.content || [];
+
     return new Place({
       id: data.placeId,
       primaryName: data.name,
@@ -223,8 +228,10 @@ export class Place {
       designations: data.designations?.[0]?.level,
       fr_designations: data.designations?.[0]?.levelFr || "",
       recognitionDate: data.designations?.[0]?.date,
-      heritageValueEn: data.culturalHistory,
-      characterDefEn: data.heritageValues?.[0]?.items?.join("\n"),
+      heritageValueEn: data.heritageValue || "",
+      characterDefEn: characterItems.join("\n"),
+      culturalHistoryEn: data.culturalHistory || "",
+      culturalHistoryFr: data.culturalHistoryFr || "",
       yHSIId: data.yhsiId,
       ThumbFile: data.ThumbFile,
     });

--- a/src/web/src/modules/places/views/Places.vue
+++ b/src/web/src/modules/places/views/Places.vue
@@ -3,31 +3,29 @@
     <v-container>
       <v-row>
         <v-col cols="12">
-          <div
-            class="d-flex flex-column flex-sm-row align-sm-center justify-space-between"
-          >
-            <h1 class="text-h4 mb-4 mb-sm-0">
+          <div class="places-list-header">
+            <h1 class="text-h4 mb-0">
               {{ t(translations.listOfHistoricPlaces) }} {{ photoCountText }}
             </h1>
-            <div class="d-flex flex-column flex-sm-row">
-              <v-select
-                v-model="sortBy"
-                :items="sortOptions"
-                :label="t(translations.sortBy)"
-                density="compact"
-                hide-details
-                class="mb-3 mb-sm-0 me-sm-3"
-                style="min-width: 220px; max-width: 280px"
-              />
-              <v-select
-                v-if="showFilter"
-                v-model="filterValue"
-                :items="filterOptions"
-                :label="filterLabel"
-                density="compact"
-                hide-details
-                style="min-width: 220px; max-width: 280px"
-              />
+            <div class="places-sort-controls">
+              <div class="places-sort-control">
+                <v-select
+                  v-model="sortBy"
+                  :items="sortOptions"
+                  :label="t(translations.sortBy)"
+                  density="compact"
+                  hide-details
+                />
+              </div>
+              <div v-if="showFilter" class="places-sort-control">
+                <v-select
+                  v-model="filterValue"
+                  :items="filterOptions"
+                  :label="filterLabel"
+                  density="compact"
+                  hide-details
+                />
+              </div>
             </div>
           </div>
         </v-col>
@@ -278,5 +276,24 @@ onMounted(() => {
 <style scoped>
 .v-col {
   transition: all 0.3s ease;
+}
+
+.places-list-header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.places-sort-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+  max-width: 280px;
+}
+
+.places-sort-control {
+  width: 100%;
 }
 </style>

--- a/src/web/src/modules/places/views/Places.vue
+++ b/src/web/src/modules/places/views/Places.vue
@@ -4,11 +4,20 @@
       <v-row>
         <v-col cols="12">
           <div
-            class="d-flex flex-column flex-sm-row align-sm-center justify-space-between gap-4"
+            class="d-flex flex-column flex-sm-row align-sm-center justify-space-between ga-4"
           >
-            <h1 class="text-h4 mb-4 mb-sm-0">
+            <h1 class="text-h4 mb-0">
               {{ t(translations.listOfHistoricPlaces) }} {{ photoCountText }}
             </h1>
+            <v-select
+              v-model="sortBy"
+              :items="sortOptions"
+              :label="t(translations.sortBy)"
+              density="compact"
+              hide-details
+              class="sort-select"
+              style="max-width: 280px"
+            />
           </div>
         </v-col>
       </v-row>
@@ -52,7 +61,7 @@
         </v-col>
       </v-row>
 
-      <v-row class="mb-2" v-if="!loading">
+      <v-row class="mb-2" v-if="!loading && numberOfPages > 1">
         <v-col>
           <div class="text-center">
             <v-pagination
@@ -72,18 +81,76 @@ import { useLanguage, translations } from "@/composables/useLanguage";
 import PlaceCard from "@/modules/places/components/PlaceCard.vue";
 import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
-import { fetchPlaces } from "../services/placesApi";
+import { fetchAllPlaces } from "../services/placesApi";
+
+const PAGE_SIZE = 12;
 
 const { t, isEnglish } = useLanguage();
 
 const router = useRouter();
 
-const numberOfPages = ref(1);
 const page = ref(1);
-const totalLength = ref(0);
-const placesList = ref([]);
+const allPlaces = ref([]);
 const loading = ref(false);
 const error = ref(null);
+const sortBy = ref("name");
+
+const sortOptions = computed(() => [
+  { title: t(translations.sortAlphabetical), value: "name" },
+  { title: t(translations.sortCommunity), value: "community" },
+  { title: t(translations.sortDesignation), value: "designation" },
+]);
+
+const sortedPlaces = computed(() => {
+  const places = [...allPlaces.value];
+  const preferEnglish = isEnglish.value;
+
+  const compareStrings = (a, b) =>
+    a.localeCompare(b, preferEnglish ? "en" : "fr", { sensitivity: "base" });
+
+  places.sort((a, b) => {
+    if (sortBy.value === "community") {
+      const communityCmp = compareStrings(
+        a.localizedLocation(preferEnglish),
+        b.localizedLocation(preferEnglish)
+      );
+      if (communityCmp !== 0) return communityCmp;
+      return compareStrings(
+        a.localizedName(preferEnglish),
+        b.localizedName(preferEnglish)
+      );
+    }
+
+    if (sortBy.value === "designation") {
+      const designationCmp = compareStrings(
+        a.localizedDesignation(preferEnglish),
+        b.localizedDesignation(preferEnglish)
+      );
+      if (designationCmp !== 0) return designationCmp;
+      return compareStrings(
+        a.localizedName(preferEnglish),
+        b.localizedName(preferEnglish)
+      );
+    }
+
+    return compareStrings(
+      a.localizedName(preferEnglish),
+      b.localizedName(preferEnglish)
+    );
+  });
+
+  return places;
+});
+
+const totalLength = computed(() => sortedPlaces.value.length);
+const numberOfPages = computed(() =>
+  Math.max(1, Math.ceil(totalLength.value / PAGE_SIZE))
+);
+
+const placesList = computed(() => {
+  const start = (page.value - 1) * PAGE_SIZE;
+  return sortedPlaces.value.slice(start, start + PAGE_SIZE);
+});
 
 const photoCountText = computed(() => {
   return totalLength.value ? `(${totalLength.value})` : "(0)";
@@ -103,11 +170,9 @@ const handleClick = (place) => {
 
 const getDataFromApi = async () => {
   loading.value = true;
+  error.value = null;
   try {
-    const response = await fetchPlaces(page.value);
-    placesList.value = response.places;
-    totalLength.value = response.total;
-    numberOfPages.value = Math.ceil(response.total / response.pageSize);
+    allPlaces.value = await fetchAllPlaces();
   } catch (err) {
     error.value = err.message;
   } finally {
@@ -115,8 +180,14 @@ const getDataFromApi = async () => {
   }
 };
 
-watch(page, () => {
-  getDataFromApi();
+watch(sortBy, () => {
+  page.value = 1;
+});
+
+watch(numberOfPages, (pages) => {
+  if (page.value > pages) {
+    page.value = pages;
+  }
 });
 
 onMounted(() => {

--- a/src/web/src/modules/places/views/Places.vue
+++ b/src/web/src/modules/places/views/Places.vue
@@ -4,20 +4,31 @@
       <v-row>
         <v-col cols="12">
           <div
-            class="d-flex flex-column flex-sm-row align-sm-center justify-space-between ga-4"
+            class="d-flex flex-column flex-sm-row align-sm-center justify-space-between"
           >
-            <h1 class="text-h4 mb-0">
+            <h1 class="text-h4 mb-4 mb-sm-0">
               {{ t(translations.listOfHistoricPlaces) }} {{ photoCountText }}
             </h1>
-            <v-select
-              v-model="sortBy"
-              :items="sortOptions"
-              :label="t(translations.sortBy)"
-              density="compact"
-              hide-details
-              class="sort-select"
-              style="max-width: 280px"
-            />
+            <div class="d-flex flex-column flex-sm-row">
+              <v-select
+                v-model="sortBy"
+                :items="sortOptions"
+                :label="t(translations.sortBy)"
+                density="compact"
+                hide-details
+                class="mb-3 mb-sm-0 me-sm-3"
+                style="min-width: 220px; max-width: 280px"
+              />
+              <v-select
+                v-if="showFilter"
+                v-model="filterValue"
+                :items="filterOptions"
+                :label="filterLabel"
+                density="compact"
+                hide-details
+                style="min-width: 220px; max-width: 280px"
+              />
+            </div>
           </div>
         </v-col>
       </v-row>
@@ -94,6 +105,7 @@ const allPlaces = ref([]);
 const loading = ref(false);
 const error = ref(null);
 const sortBy = ref("name");
+const filterValue = ref("");
 
 const sortOptions = computed(() => [
   { title: t(translations.sortAlphabetical), value: "name" },
@@ -101,8 +113,71 @@ const sortOptions = computed(() => [
   { title: t(translations.sortDesignation), value: "designation" },
 ]);
 
+const showFilter = computed(
+  () => sortBy.value === "community" || sortBy.value === "designation"
+);
+
+const filterLabel = computed(() =>
+  sortBy.value === "community"
+    ? t(translations.filterCommunity)
+    : t(translations.filterDesignation)
+);
+
+const uniqueSortedOptions = (entries, preferEnglish) => {
+  const locale = preferEnglish ? "en" : "fr";
+  return [...entries.entries()]
+    .sort((a, b) => a[1].localeCompare(b[1], locale, { sensitivity: "base" }))
+    .map(([value, title]) => ({ title, value }));
+};
+
+const filterOptions = computed(() => {
+  const preferEnglish = isEnglish.value;
+  const allOption = { title: t(translations.filterAll), value: "" };
+  const entries = new Map();
+
+  if (sortBy.value === "community") {
+    for (const place of allPlaces.value) {
+      const value = place.communityName || place.localizedLocation(true);
+      if (!value || entries.has(value)) continue;
+      entries.set(value, place.localizedLocation(preferEnglish) || value);
+    }
+  } else if (sortBy.value === "designation") {
+    for (const place of allPlaces.value) {
+      const value =
+        place.designations?.[0]?.level || place.localizedDesignation(true);
+      if (!value || entries.has(value)) continue;
+      entries.set(value, place.localizedDesignation(preferEnglish) || value);
+    }
+  }
+
+  return [allOption, ...uniqueSortedOptions(entries, preferEnglish)];
+});
+
+const filteredPlaces = computed(() => {
+  const places = allPlaces.value;
+  if (!filterValue.value || !showFilter.value) return places;
+
+  if (sortBy.value === "community") {
+    return places.filter(
+      (place) =>
+        (place.communityName || place.localizedLocation(true)) ===
+        filterValue.value
+    );
+  }
+
+  if (sortBy.value === "designation") {
+    return places.filter(
+      (place) =>
+        (place.designations?.[0]?.level || place.localizedDesignation(true)) ===
+        filterValue.value
+    );
+  }
+
+  return places;
+});
+
 const sortedPlaces = computed(() => {
-  const places = [...allPlaces.value];
+  const places = [...filteredPlaces.value];
   const preferEnglish = isEnglish.value;
 
   const compareStrings = (a, b) =>
@@ -181,6 +256,11 @@ const getDataFromApi = async () => {
 };
 
 watch(sortBy, () => {
+  filterValue.value = "";
+  page.value = 1;
+});
+
+watch(filterValue, () => {
   page.value = 1;
 });
 

--- a/src/web/src/modules/places/views/PlacesForm.vue
+++ b/src/web/src/modules/places/views/PlacesForm.vue
@@ -21,12 +21,15 @@
         <v-row>
           <v-col cols="12">
             <h1 class="text-h4 mb-2">{{ displayName }}</h1>
+            <p v-if="placeDescription" class="text-h6 font-weight-regular mb-4">
+              {{ placeDescription }}
+            </p>
           </v-col>
         </v-row>
 
         <v-row>
           <v-col cols="12" md="8">
-            <PlaceGallery :place-id="placeId" />
+            <PlaceGallery :place-id="placeId" :height="mapHeight" />
           </v-col>
           <v-col cols="12" md="4">
             <v-card color="grey-lighten-1" :height="mapHeight">
@@ -39,15 +42,9 @@
           </v-col>
         </v-row>
 
-        <v-row v-if="placeDescription">
+        <v-row class="mt-4">
           <v-col cols="12">
-            <p class="text-subtitle-1 mb-4">{{ placeDescription }}</p>
-          </v-col>
-        </v-row>
-
-        <v-row>
-          <v-col cols="12">
-            <v-expansion-panels multiple>
+            <v-expansion-panels v-model="openPanels" multiple>
               <v-expansion-panel v-for="panel in expansionPanels" :key="panel.title">
                 <v-expansion-panel-title class="bg-grey-lighten-4">
                   {{ panel.title }}
@@ -86,6 +83,7 @@ const { t, isEnglish } = useLanguage();
 const loading = ref(false);
 const error = ref(null);
 const placeData = ref(null);
+const openPanels = ref([]);
 
 const mapHeight = computed(() => (smAndDown.value ? 300 : 500));
 
@@ -118,10 +116,6 @@ const expansionPanels = computed(() => {
         : "",
     },
     {
-      title: t(translations.placeDescription),
-      content: getLocalizedField("placeDescriptionEn", "placeDescriptionFr"),
-    },
-    {
       title: t(translations.heritageValue),
       content: getLocalizedField("heritageValueEn", "heritageValueFr"),
     },
@@ -139,6 +133,14 @@ const expansionPanels = computed(() => {
     },
   ].filter((p) => p.content);
 });
+
+watch(
+  expansionPanels,
+  (panels) => {
+    openPanels.value = panels.map((_, index) => index);
+  },
+  { immediate: true }
+);
 
 const fetchPlaceDetails = async () => {
   loading.value = true;

--- a/src/web/src/modules/places/views/PlacesForm.vue
+++ b/src/web/src/modules/places/views/PlacesForm.vue
@@ -131,6 +131,10 @@ const expansionPanels = computed(() => {
       title: t(translations.descriptionOfBoundaries),
       content: getLocalizedField("descBoundEn", "descBoundFr"),
     },
+    {
+      title: t(translations.culturalHistory),
+      content: getLocalizedField("culturalHistoryEn", "culturalHistoryFr"),
+    },
   ].filter((p) => p.content);
 });
 

--- a/src/web/src/router.js
+++ b/src/web/src/router.js
@@ -1,3 +1,4 @@
+import contactRoutes from "@/modules/contact/router";
 import homeRoutes from "@/modules/home/router";
 import mapRoutes from "@/modules/map/router";
 import placesRoutes from "@/modules/places/router";
@@ -7,7 +8,7 @@ const routes = [
   {
     path: "/",
     component: () => import("@/layouts/Blank.vue"),
-    children: [...homeRoutes, ...mapRoutes, ...placesRoutes],
+    children: [...homeRoutes, ...mapRoutes, ...placesRoutes, ...contactRoutes],
   },
   {
     path: "/:pathMatch(.*)*",


### PR DESCRIPTION

[YRHP_Comments_Lee.docx](https://github.com/user-attachments/files/30860927/YRHP_Comments_Lee.docx)
## Summary
- Home intro emphasized as a bold central heading; Contact Us page with Historic Sites email/phone
- Places list sorting by name/community/designation, plus a filter dropdown for community or designation
- Place detail: description under title, gallery aligned with map, open panels, Character-Defining Elements rename, Cultural History panel (YHIS field pending)

## Test plan
- [x] Home: intro reads as one emphasized block; EN/FR toggle works
- [x] Nav → Contact Us: email `historic.sites@yukon.ca` and phone `867-667-5386` work
- [x] Places: sort alphabetical / community / designation; filter appears and narrows results; controls sit under the list heading with vertical spacing
- [x] Place detail: description under name; photos less cropped; single caption; panels open by default; CDE label correct
- [x] Cultural History panel shows when data exists (mock); live YHIS may still omit the field


Note: Cultural History data is not being surfaced by the YHIS API at this time. 